### PR TITLE
Add new grpc message to extract fs-state from sysbox-mgr

### DIFF
--- a/sysboxMgrGrpc/sysboxMgrProtobuf/sysboxMgrProtobuf.proto
+++ b/sysboxMgrGrpc/sysboxMgrProtobuf/sysboxMgrProtobuf.proto
@@ -31,6 +31,9 @@ service sysboxMgrStateChannel {
     // Shiftfs mark request
     rpc ReqShiftfsMark (ShiftfsMarkReq) returns (ShiftfsMarkResp) {}
 
+    // FsState request
+    rpc ReqFsState (FsStateReq) returns (FsStateResp) {}
+
     // Pause request
     rpc Pause (PauseReq) returns (PauseResp) {}
 }
@@ -137,6 +140,26 @@ message ShiftfsMarkReq {
 }
 
 message ShiftfsMarkResp {
+}
+
+//
+// FsState Requests
+//
+
+message FsStateReq {
+    string id = 1;
+    string rootfs = 2;
+}
+
+message FsEntry {
+    uint32 kind = 1;
+    string path = 2;
+    uint32 mode = 3;
+    string dst = 4;
+}
+
+message FsStateResp {
+    repeated FsEntry fsEntries = 1;
 }
 
 //


### PR DESCRIPTION
This new ipc is required to allow sysbox-runc to inquire sysbox-mgr for file-system state that must be added to container's rootfs (e.g. linux-kernel-header softlink is a first example).

Signed-off-by: Rodny Molina <rmolina@nestybox.com>