### PR TITLE
Add GetMountpoint() API to sysbox-fs gRPC.

### DIFF
--- a/sysboxFsGrpc/grpcClient.go
+++ b/sysboxFsGrpc/grpcClient.go
@@ -235,3 +235,26 @@ func SendContainerUpdate(data *ContainerData) (err error) {
 
 	return nil
 }
+
+func GetMountpoint() (string, error) {
+	var mpResp *pb.MountpointResp
+
+	// Set up sysbox-fs pipeline.
+	conn, err := connect()
+	if err != nil {
+		return "", fmt.Errorf("failed to connect with sysbox-fs: %v", err)
+	}
+	defer conn.Close()
+
+	cntrChanIntf := pb.NewSysboxStateChannelClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	mpResp, err = cntrChanIntf.GetMountpoint(ctx, &pb.MountpointReq{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get sysbox-fs mountpoint: %v", err)
+	}
+
+	return mpResp.GetMountpoint(), nil
+}

--- a/sysboxFsGrpc/grpcServer.go
+++ b/sysboxFsGrpc/grpcServer.go
@@ -45,6 +45,7 @@ const (
 	ContainerRegisterMessage
 	ContainerUnregisterMessage
 	ContainerUpdateMessage
+	GetMountpointMessage
 	MaxSupportedMessage
 )
 
@@ -65,9 +66,10 @@ type CallbacksMap = map[MessageType]Callback
 type Server struct {
 	Ctx       interface{}
 	Callbacks CallbacksMap
+	FuseMp    string
 }
 
-func NewServer(ctx interface{}, cb *CallbacksMap) *Server {
+func NewServer(ctx interface{}, cb *CallbacksMap, fuseMp string) *Server {
 
 	if cb == nil {
 		return nil
@@ -84,6 +86,7 @@ func NewServer(ctx interface{}, cb *CallbacksMap) *Server {
 	newServer := &Server{
 		Ctx:       ctx,
 		Callbacks: make(map[MessageType]Callback),
+		FuseMp:    fuseMp,
 	}
 
 	for ctype, cval := range *cb {
@@ -153,6 +156,11 @@ func (s *Server) ContainerUpdate(
 	ctx context.Context, data *pb.ContainerData) (*pb.Response, error) {
 
 	return s.executeCallback(ContainerUpdateMessage, data)
+}
+
+func (s *Server) GetMountpoint(
+	ctx context.Context, req *pb.MountpointReq) (*pb.MountpointResp, error) {
+	return &pb.MountpointResp{Mountpoint: s.FuseMp}, nil
 }
 
 func (s *Server) executeCallback(mtype MessageType,

--- a/sysboxFsGrpc/sysboxFsProtobuf/sysboxFsProtobuf.proto
+++ b/sysboxFsGrpc/sysboxFsProtobuf/sysboxFsProtobuf.proto
@@ -13,6 +13,9 @@ package protobuf;
 // ContainerRegistration/Unregistration service definition.
 service sysboxStateChannel {
 
+    // Queries sysbox-fs for the FUSE mountpoint
+    rpc GetMountpoint(MountpointReq) returns (MountpointResp) {}
+
     // Generates a container-preregistration message
     rpc ContainerPreRegistration (ContainerData) returns (Response) {}
 
@@ -47,4 +50,11 @@ message ContainerData {
 // Response message sent from sysbox-fs to runC process.
 message Response {
   bool Success = 1;
+}
+
+message MountpointReq {
+}
+
+message MountpointResp {
+  string Mountpoint = 1;
 }


### PR DESCRIPTION
This API allows sysbox-runc to query sysbox-fs for
the FUSE mountpoint location.

This change is needed to fix Sysbox issue #310.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>