### PR TITLE
Modify sysbox-runc -> sysbox-mgr gRPC to allow uid shifting per mount request.

### DIFF
--- a/sysboxMgrGrpc/grpcClient.go
+++ b/sysboxMgrGrpc/grpcClient.go
@@ -162,7 +162,7 @@ func SubidAlloc(id string, size uint64) (uint32, uint32, error) {
 }
 
 // ReqMounts requests the sysbox-mgr to setup sys container special mounts
-func ReqMounts(id, rootfs string, uid, gid uint32, shiftUids bool, reqList []ipcLib.MountReqInfo) ([]specs.Mount, error) {
+func ReqMounts(id, rootfs string, uid, gid uint32, reqList []ipcLib.MountReqInfo) ([]specs.Mount, error) {
 
 	conn, err := connect()
 	if err != nil {
@@ -181,19 +181,19 @@ func ReqMounts(id, rootfs string, uid, gid uint32, shiftUids bool, reqList []ipc
 	pbReqList := []*pb.MountReqInfo{}
 	for _, info := range reqList {
 		pbInfo := &pb.MountReqInfo{
-			Kind: uint32(info.Kind),
-			Dest: info.Dest,
+			Kind:      uint32(info.Kind),
+			Dest:      info.Dest,
+			ShiftUids: info.ShiftUids,
 		}
 		pbReqList = append(pbReqList, pbInfo)
 	}
 
 	req := &pb.MountReq{
-		Id:        id,
-		Rootfs:    rootfs,
-		Uid:       uid,
-		Gid:       gid,
-		ShiftUids: shiftUids,
-		ReqList:   pbReqList,
+		Id:      id,
+		Rootfs:  rootfs,
+		Uid:     uid,
+		Gid:     gid,
+		ReqList: pbReqList,
 	}
 
 	resp, err := ch.ReqMounts(ctx, req)
@@ -294,7 +294,7 @@ func ReqShiftfsMark(id string, mounts []configs.ShiftfsMount) ([]configs.Shiftfs
 	markpoints := []configs.ShiftfsMount{}
 	for _, m := range resp.GetShiftfsMarks() {
 		sm := configs.ShiftfsMount{
-			Source: m.Source,
+			Source:   m.Source,
 			Readonly: m.Readonly,
 		}
 		markpoints = append(markpoints, sm)

--- a/sysboxMgrGrpc/grpcServer.go
+++ b/sysboxMgrGrpc/grpcServer.go
@@ -42,7 +42,7 @@ type ServerCallbacks struct {
 	Update         func(updateInfo *ipcLib.UpdateInfo) error
 	Unregister     func(id string) error
 	SubidAlloc     func(id string, size uint64) (uint32, uint32, error)
-	ReqMounts      func(id, rootfs string, uid, gid uint32, shiftUids bool, reqList []ipcLib.MountReqInfo) ([]specs.Mount, error)
+	ReqMounts      func(id, rootfs string, uid, gid uint32, reqList []ipcLib.MountReqInfo) ([]specs.Mount, error)
 	PrepMounts     func(id string, uid, gid uint32, prepList []ipcLib.MountPrepInfo) error
 	ReqShiftfsMark func(id string, mounts []configs.ShiftfsMount) ([]configs.ShiftfsMount, error)
 	ReqFsState     func(id string, rootfs string) ([]configs.FsEntry, error)
@@ -187,13 +187,14 @@ func (s *ServerStub) ReqMounts(ctx context.Context, req *pb.MountReq) (*pb.Mount
 	reqList := []ipcLib.MountReqInfo{}
 	for _, pbInfo := range req.ReqList {
 		info := ipcLib.MountReqInfo{
-			Kind: ipcLib.MntKind(pbInfo.GetKind()),
-			Dest: pbInfo.GetDest(),
+			Kind:      ipcLib.MntKind(pbInfo.GetKind()),
+			Dest:      pbInfo.GetDest(),
+			ShiftUids: pbInfo.GetShiftUids(),
 		}
 		reqList = append(reqList, info)
 	}
 
-	mounts, err := s.cb.ReqMounts(req.GetId(), req.GetRootfs(), req.GetUid(), req.GetGid(), req.GetShiftUids(), reqList)
+	mounts, err := s.cb.ReqMounts(req.GetId(), req.GetRootfs(), req.GetUid(), req.GetGid(), reqList)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +262,7 @@ func (s *ServerStub) ReqShiftfsMark(ctx context.Context, req *pb.ShiftfsMarkReq)
 	markResp := []*pb.ShiftfsMark{}
 	for _, m := range respList {
 		sm := &pb.ShiftfsMark{
-			Source: m.Source,
+			Source:   m.Source,
 			Readonly: m.Readonly,
 		}
 		markResp = append(markResp, sm)

--- a/sysboxMgrGrpc/sysboxMgrProtobuf/sysboxMgrProtobuf.proto
+++ b/sysboxMgrGrpc/sysboxMgrProtobuf/sysboxMgrProtobuf.proto
@@ -129,6 +129,7 @@ message MountPrepResp {
 message MountReqInfo {
     uint32 kind = 1;
     string dest = 2;
+    bool shiftUids = 3;
 }
 
 message MountReq {
@@ -136,8 +137,7 @@ message MountReq {
     string rootfs = 2;
     uint32 uid = 3;
     uint32 gid = 4;
-    bool shiftUids = 5;
-    repeated MountReqInfo reqList = 6;
+    repeated MountReqInfo reqList = 5;
 }
 
 message Mount {

--- a/sysboxMgrLib/sysboxMgrLib.go
+++ b/sysboxMgrLib/sysboxMgrLib.go
@@ -90,6 +90,7 @@ func (k MntKind) String() string {
 }
 
 type MountReqInfo struct {
-	Kind MntKind
-	Dest string
+	Kind      MntKind
+	Dest      string
+	ShiftUids bool
 }


### PR DESCRIPTION
This is part of the solution for Sysbox issue #254. It complements related
changes in sysbox-runc and sysbox-mgr.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>