### PR TITLE
Adjust runc's references in go.mod to reflect latests sync-ups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/protobuf v1.4.1
-	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
+	github.com/opencontainers/runc v1.0.0-rc9.0.20210126000000-2be806d1391d
 	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f


### PR DESCRIPTION
Refer to PR [#63](https://github.com/nestybox/sysbox-runc/pull/63) for details.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>