### PR TITLE
feat: Add external user namespace support

### DIFF
--- a/sysboxMgrGrpc/grpcClient.go
+++ b/sysboxMgrGrpc/grpcClient.go
@@ -65,12 +65,13 @@ func Register(regInfo *ipcLib.RegistrationInfo) (*ipcLib.ContainerConfig, error)
 	defer cancel()
 
 	req := &pb.RegisterReq{
-		Id:          regInfo.Id,
-		Rootfs:      regInfo.Rootfs,
-		Userns:      regInfo.Userns,
-		Netns:       regInfo.Netns,
-		UidMappings: linuxIDMapToProtoIDMap(regInfo.UidMappings),
-		GidMappings: linuxIDMapToProtoIDMap(regInfo.GidMappings),
+		Id:             regInfo.Id,
+		Rootfs:         regInfo.Rootfs,
+		Userns:         regInfo.Userns,
+		Netns:          regInfo.Netns,
+		UidMappings:    linuxIDMapToProtoIDMap(regInfo.UidMappings),
+		GidMappings:    linuxIDMapToProtoIDMap(regInfo.GidMappings),
+		ExternalUserNS: regInfo.ExternalUserNS,
 	}
 
 	resp, err := ch.Register(ctx, req)

--- a/sysboxMgrGrpc/grpcServer.go
+++ b/sysboxMgrGrpc/grpcServer.go
@@ -109,12 +109,13 @@ func (s *ServerStub) Register(ctx context.Context, req *pb.RegisterReq) (*pb.Reg
 	}
 
 	regInfo := &ipcLib.RegistrationInfo{
-		Id:          req.GetId(),
-		Rootfs:      req.GetRootfs(),
-		Userns:      req.GetUserns(),
-		Netns:       req.GetNetns(),
-		UidMappings: protoIDMapToLinuxIDMap(req.GetUidMappings()),
-		GidMappings: protoIDMapToLinuxIDMap(req.GetGidMappings()),
+		Id:             req.GetId(),
+		Rootfs:         req.GetRootfs(),
+		Userns:         req.GetUserns(),
+		Netns:          req.GetNetns(),
+		UidMappings:    protoIDMapToLinuxIDMap(req.GetUidMappings()),
+		GidMappings:    protoIDMapToLinuxIDMap(req.GetGidMappings()),
+		ExternalUserNS: req.GetExternalUserNS(),
 	}
 
 	config, err := s.cb.Register(regInfo)

--- a/sysboxMgrGrpc/sysboxMgrProtobuf/sysboxMgrProtobuf.proto
+++ b/sysboxMgrGrpc/sysboxMgrProtobuf/sysboxMgrProtobuf.proto
@@ -70,6 +70,7 @@ message RegisterReq {
     string netns = 4;
     repeated IDMapping uidMappings = 5;
     repeated IDMapping gidMappings = 6;
+    bool externalUserNS = 7;  // when true, use provided mappings; do not allocate from pool
 }
 
 message ContainerConfig {

--- a/sysboxMgrLib/sysboxMgrLib.go
+++ b/sysboxMgrLib/sysboxMgrLib.go
@@ -25,12 +25,13 @@ import (
 
 // Sysbox-mgr container registration info
 type RegistrationInfo struct {
-	Id          string
-	Rootfs      string
-	Userns      string
-	Netns       string
-	UidMappings []specs.LinuxIDMapping
-	GidMappings []specs.LinuxIDMapping
+	Id              string
+	Rootfs          string
+	Userns          string
+	Netns           string
+	UidMappings     []specs.LinuxIDMapping
+	GidMappings     []specs.LinuxIDMapping
+	ExternalUserNS  bool // when true, mappings are from K8s/Containerd; do not allocate from pool
 }
 
 // Sysbox-mgr container update info


### PR DESCRIPTION
# Support for externally created user namespaces (e.g. Kubernetes 1.33 `hostUsers: false`)

## Summary

This change adds support for **externally created user namespaces**, such as those created by Kubernetes 1.33 when using `hostUsers: false`. Sysbox can now attach to and manage containers that run inside user namespaces created by the orchestrator rather than by Sysbox itself.

## Motivation

Kubernetes 1.33 introduces the ability to run pods with `hostUsers: false`, which creates a user namespace per pod. For Sysbox to support this model, it must:

- Detect when the container is already running in an external user namespace
- Use that namespace instead of creating its own
- Coordinate with sysbox-mgr and sysbox-ipc so that ID mappings, rootfs, and other Sysbox features work correctly with the external userns

This PR (along with the related changes in sysbox-ipc and sysbox-mgr) implements that support end-to-end.

## Related PRs

This is part of a coordinated change across the Sysbox repos. Please review and merge in dependency order where applicable:

- **sysbox-runc:** [link to sysbox-runc PR](https://github.com/nestybox/sysbox-runc/pull/109)
- **sysbox-ipc:** [link to sysbox-ipc PR](https://github.com/nestybox/sysbox-ipc/pull/36)
- **sysbox-mgr:** [link to sysbox-mgr PR](https://github.com/nestybox/sysbox-mgr/pull/79)

## Testing

Tested on **AWS EKS 1.33.5** with **Amazon Linux 2023** (kernel **6.1**) using containerd.

The following pod spec was used to verify behavior with `hostUsers: false` and `runtimeClassName: sysbox-runc`. The pod runs a systemd-based workload with Docker Compose (Postgres, Nginx, Redis) inside the Sysbox container:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: debian13
spec:
  hostUsers: false
  runtimeClassName: sysbox-runc
  containers:
  - name: dev
    image: <your-image>   # Replace with your container image
    command: ["sh", "-c"]
    args:
    - |
      # Create the working directory
      mkdir -p /opt/myapp

      # Create the docker-compose.yml
      cat > /opt/myapp/docker-compose.yml << 'EOF_COMPOSE'
      services:
        db:
          image: postgres:latest
          container_name: postgres
          environment:
            POSTGRES_USER: your_user
            POSTGRES_PASSWORD: your_password
            POSTGRES_DB: your_database
        web:
          image: nginx:latest
          container_name: nginx
        cache:
          image: redis:latest
          container_name: redis
      EOF_COMPOSE

      # Create the systemd service file using a heredoc
      cat > /etc/systemd/system/sysboxbddtest.service << 'EOF_SERVICE'
      [Unit]
      Description=My Docker Compose Application
      Requires=docker.service
      After=docker.service

      [Service]
      WorkingDirectory=/opt/myapp
      ExecStart=/usr/bin/docker compose -p myapp up
      ExecStop=/usr/bin/docker compose -p myapp down
      Restart=no

      [Install]
      WantedBy=multi-user.target
      EOF_SERVICE

      systemctl enable sysboxbddtest.service
      exec /sbin/init
  restartPolicy: Never
```

**Test environment:**

| Component   | Version / details        |
|------------|---------------------------|
| Kubernetes | AWS EKS 1.33.5           |
| OS         | Amazon Linux 2023        |
| Kernel     | 6.1                       |
|Runtime  | Containerd |

Added the following to `/etc/containerd/config.toml`:

```
[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc]
  runtime_type = "io.containerd.runc.v2"
  base_runtime_spec = "/etc/containerd/sysbox-base-spec.json"
  
[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.sysbox-runc.options]
  BinaryName = "/usr/bin/sysbox-runc"
  SupportsUserns = true
```

Created `/etc/containerd/sysbox-base-spec.json`:

```
{
  "ociVersion": "1.0.2",
  "process": {
    "capabilities": {
      "bounding": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "effective": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "inheritable": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "permitted": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"],
      "ambient": ["CAP_SYS_ADMIN", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_ADMIN", "CAP_SETGID", "CAP_SETUID", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE"]
    }
  },
  "linux": {
    "seccomp": {
      "defaultAction": "SCMP_ACT_ALLOW",
      "architectures": ["SCMP_ARCH_X86_64", "SCMP_ARCH_X86", "SCMP_ARCH_AARCH64", "SCMP_ARCH_ARM"],
      "syscalls": []
    }
  }
}
```

With this configuration, the pod runs with an externally created user namespace (`hostUsers: false`), and Sysbox correctly manages the container (systemd, Docker Compose, and nested containers) within that namespace.
